### PR TITLE
Deleting \usepackage{tocloft} from use_package.tex

### DIFF
--- a/ThesisTemplate2017/macros/use_packages.tex
+++ b/ThesisTemplate2017/macros/use_packages.tex
@@ -111,15 +111,7 @@
 \subsectionfont{\normalsize}
 
 % for formatting Table of Contents entry, example: Chapter 1 Introduction
-\usepackage{tocloft}
-\renewcommand{\cftchappresnum}{Chapter }
-\renewcommand{\cftchapaftersnum}{:}
-\renewcommand{\cftchapnumwidth}{7em}
 
-% for formatting Table of Contents entry for Appendix, example: Appendix 1: Stuff
-\newcommand*\updatechaptername{%
-	\addtocontents{toc}{\protect\renewcommand*\protect\cftchappresnum{Appendix }}
-}
 
 %*************************************************************************************************************
 % GLOSSARY


### PR DESCRIPTION
This \usepackage{tocloft} is overwriting a second \usepackage{tocloft} in style.tex which seems to be setup correctly. Not 100% sure if this is the problem.

Alternatively this could be moved to style section.